### PR TITLE
Adding support for secondary I2C interfaces found on some boards.

### DIFF
--- a/i2cdetect.cpp
+++ b/i2cdetect.cpp
@@ -21,7 +21,7 @@ void _printf(const char *format, ...)
   va_end(ap);
 }
 
-void i2cdetect(uint8_t first, uint8_t last) {
+void i2cdetect(TwoWire &wire, uint8_t first, uint8_t last) {
   uint8_t i, j, address, error;
 
   // header
@@ -36,8 +36,8 @@ void i2cdetect(uint8_t first, uint8_t last) {
     for (i = 0; i < 16; i++) {
       address = i + j*16;
       if (address >= first && address <= last) {
-        Wire.beginTransmission(address);
-        error = Wire.endTransmission();
+        wire.beginTransmission(address);
+        error = wire.endTransmission();
         if (error) {
           Serial.print(" --");
         } else {

--- a/i2cdetect.h
+++ b/i2cdetect.h
@@ -1,8 +1,12 @@
+/*
+i2cdetect.h - Arduino library for scanning I2C bus for devices
+*/
 
 #ifndef __I2CDETECT_H_
 #define __I2CDETECT_H_
 
-void i2cdetect(uint8_t first, uint8_t last);
-void i2cdetect();
+#include <Wire.h>
+
+void i2cdetect(TwoWire &wire = Wire, uint8_t first = 0x03, uint8_t last = 0x77);
 
 #endif


### PR DESCRIPTION
I have an Arduino Due and I want to detect devices on the secondary I2C bus. This modification shouldn't break the compatibility to existing code in most cases.